### PR TITLE
Remove dependency on regex-compat

### DIFF
--- a/System/Environment/XDG/BaseDir.hs
+++ b/System/Environment/XDG/BaseDir.hs
@@ -18,17 +18,13 @@ module System.Environment.XDG.BaseDir
     ) where
 
 import Data.Maybe         ( fromMaybe )
-import System.FilePath    ( (</>) )
+import System.FilePath    ( (</>), splitSearchPath )
 import System.Environment ( getEnvironment, getEnv )
 import System.IO.Error    ( try )
-import Text.Regex         ( splitRegex, mkRegex, Regex )
 import System.Directory   ( getHomeDirectory )
 import Control.Monad      ( liftM2 )
 
 #if defined(mingw32_HOST_OS) || defined(__MINGW32__)
-
-splitDirs :: String -> [String]
-splitDirs = splitRegex $ mkRegex ";"
 
 getDefault "XDG_DATA_HOME"   = getEnv "AppData"
 getDefault "XDG_CONFIG_HOME" = userRelative $ "Local Settings"
@@ -38,9 +34,6 @@ getDefault "XDG_CONFIG_DIRS" = getEnv "ProgramFiles"
 getDefault _                 = return ""
 
 #else
-
-splitDirs :: String -> [String]
-splitDirs = splitRegex $ mkRegex ":"
 
 getDefault "XDG_DATA_HOME"   = userRelative $ ".local" </> "share"
 getDefault "XDG_CONFIG_HOME" = userRelative $ ".config"
@@ -98,7 +91,7 @@ singleDir :: String -> String -> IO FilePath
 singleDir key app = envLookup key >>= return . (</> app)
 
 multiDirs :: String -> String -> IO [FilePath]
-multiDirs key app = envLookup key >>= return . map (</> app) . splitDirs
+multiDirs key app = envLookup key >>= return . map (</> app) . splitSearchPath
 
 envLookup :: String -> IO String
 envLookup key = do env <- getEnvironment

--- a/xdg-basedir.cabal
+++ b/xdg-basedir.cabal
@@ -22,7 +22,7 @@ cabal-version: >= 1.6
 
 library
   exposed-modules: System.Environment.XDG.BaseDir
-  build-depends:   base >= 4 && < 5, regex-compat, directory, filepath
+  build-depends:   base >= 4 && < 5, directory, filepath
 
 source-repository head
   type:      git


### PR DESCRIPTION
By using `splitSearchPath` from the filepath library it is not necessary to use regex based splitting.  As far as I can see the `splitSearchPath` function has been in filepath forever so there should be no problems with version compatibility.
