### PR TITLE
Partially handle no $HOME

### DIFF
--- a/System/Environment/XDG/BaseDir.hs
+++ b/System/Environment/XDG/BaseDir.hs
@@ -17,9 +17,8 @@ module System.Environment.XDG.BaseDir
     , getAllConfigFiles
     ) where
 
-import Data.Maybe         ( fromMaybe )
 import System.FilePath    ( (</>), splitSearchPath )
-import System.Environment ( getEnvironment, getEnv )
+import System.Environment ( getEnvironment )
 import Control.Exception  ( IOException, try )
 import System.Directory   ( getHomeDirectory )
 import Control.Monad      ( liftM2 )

--- a/System/Environment/XDG/BaseDir.hs
+++ b/System/Environment/XDG/BaseDir.hs
@@ -20,7 +20,7 @@ module System.Environment.XDG.BaseDir
 import Data.Maybe         ( fromMaybe )
 import System.FilePath    ( (</>), splitSearchPath )
 import System.Environment ( getEnvironment, getEnv )
-import Control.Exception    ( try )
+import Control.Exception  ( IOException, try )
 import System.Directory   ( getHomeDirectory )
 import Control.Monad      ( liftM2 )
 
@@ -61,10 +61,10 @@ getSystemConfigDirs :: String -> IO [FilePath]
 getSystemConfigDirs = multiDirs "XDG_CONFIG_DIRS"
 -- | Get a list of all data directories.
 getAllDataDirs      :: String -> IO [FilePath]
-getAllDataDirs a    = liftM2 (:) (getUserDataDir a) (getSystemDataDirs a)
+getAllDataDirs a    = liftM2 (++) (possibleSingleDir "XDG_DATA_HOME" a) (getSystemDataDirs a)
 -- | Get a list of all configuration directories.
 getAllConfigDirs    :: String -> IO [FilePath]
-getAllConfigDirs a  = liftM2 (:) (getUserConfigDir a) (getSystemConfigDirs a)
+getAllConfigDirs a  = liftM2 (++) (possibleSingleDir "XDG_CONFIG_HOME" a) (getSystemConfigDirs a)
 -- | Get the path to a specific user data file.
 getUserDataFile          :: String -> String -> IO FilePath
 getUserDataFile a f      = fmap (</> f) $ getUserDataDir a
@@ -86,6 +86,12 @@ getAllDataFiles a f      = fmap (map (</> f)) $ getAllDataDirs a
 -- | Get a list of all paths for a specific configuration file.
 getAllConfigFiles        :: String -> String -> IO [FilePath]
 getAllConfigFiles a f    = fmap (map (</> f)) $ getAllConfigDirs a
+
+possibleSingleDir :: String -> String -> IO [FilePath]
+possibleSingleDir key app = fmap ignoreIOEx . try $ singleDir key app where
+    ignoreIOEx :: Either IOException FilePath -> [FilePath]
+    ignoreIOEx (Left  _) = []
+    ignoreIOEx (Right d) = [d]
 
 singleDir :: String -> String -> IO FilePath
 singleDir key app = envLookup key >>= return . (</> app)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE CPP #-}
+
+module Main where
+
+import Data.List ( isPrefixOf )
+import System.Environment ( setEnv, unsetEnv )
+import System.Environment.XDG.BaseDir ( getAllDataDirs )
+import Test.Hspec ( Spec, hspec, describe, it, shouldSatisfy )
+
+spec :: Spec
+spec =
+#if defined(mingw32_HOST_OS) || defined(__MINGW32__)
+    return () -- nothing to test for Windows
+#elif MIN_VERSION_base(4,7,0)
+    describe "getAllDataDirs" $ do
+        it "works when $HOME is set" $ do
+            setEnv "HOME" "/atesthome"
+            getAllDataDirs "test" >>= (`shouldSatisfy` (isPrefixOf "/atesthome" . head))
+
+        it "works when $HOME isn't set" $ do
+            unsetEnv "HOME"
+            getAllDataDirs "test" >>= (`shouldSatisfy` ((> 0) . length))
+#else
+    return () -- don't have (un)setEnv in base <4.7, so can't test
+#endif
+
+main :: IO ()
+main = hspec spec

--- a/xdg-basedir.cabal
+++ b/xdg-basedir.cabal
@@ -24,6 +24,12 @@ library
   exposed-modules: System.Environment.XDG.BaseDir
   build-depends:   base >= 4 && < 5, directory, filepath
 
+test-suite spec
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: ., test
+  main-is:        Spec.hs
+  build-depends:  base >= 4 && < 5, directory, filepath, hspec
+
 source-repository head
   type:      git
   location:  git://github.com/willdonnelly/xdg-basedir.git


### PR DESCRIPTION
Avoid crashing when calling the `getAll*` functions when `$HOME` isn't set. I can't see an easy fix for the `getUser*` functions that don't involve changing the type signature.

This is a partial fix for issue #6.

Tested with GHC 7.8.4 / Cabal 1.20.0.0.
